### PR TITLE
Improve error handling in Darwin implementation

### DIFF
--- a/screenshot_darwin.go
+++ b/screenshot_darwin.go
@@ -6,6 +6,7 @@ import (
 	// #include <CoreGraphics/CoreGraphics.h>
 	// #include <CoreFoundation/CoreFoundation.h>
 	"C"
+	"fmt"
 	"image"
 	"math"
 	"reflect"
@@ -30,12 +31,29 @@ func CaptureScreen() (*image.RGBA, error) {
 func CaptureRect(rect image.Rectangle) (*image.RGBA, error) {
 	displayID := C.CGMainDisplayID()
 	width := int(math.Ceil(float64(C.CGDisplayPixelsWide(displayID))/16) * 16)
-	cgImage := C.CGDisplayCreateImage(displayID)
-	cgDataProvider := C.CGImageGetDataProvider(cgImage)
-	cgRawData := C.CGDataProviderCopyData(cgDataProvider)
 
-	length := int(C.CFDataGetLength(cgRawData))
-	ptr := unsafe.Pointer(C.CFDataGetBytePtr(cgRawData))
+	// the three variables below are named after their CoreFoundation and
+	// CoreGraphics types for ease of reference; all are of type uintptr in Go
+	cgImageRef := C.CGDisplayCreateImage(displayID)
+	if cgImageRef == 0 {
+		return nil, fmt.Errorf("CGDisplayCreateImage(%d) returned null", displayID)
+	}
+	defer C.CGImageRelease(C.CGImageRef(cgImageRef))
+
+	cgDataProviderRef := C.CGImageGetDataProvider(cgImageRef)
+	if cgDataProviderRef == 0 {
+		return nil, fmt.Errorf("CGImageGetDataProvider returned null")
+	}
+	defer C.CFRelease(C.CFTypeRef(cgDataProviderRef))
+
+	cfDataRef := C.CGDataProviderCopyData(cgDataProviderRef)
+	if cfDataRef == 0 {
+		return nil, fmt.Errorf("CGDataProviderCopyData returned null")
+	}
+	defer C.CFRelease(C.CFTypeRef(cfDataRef))
+
+	length := int(C.CFDataGetLength(cfDataRef))
+	ptr := unsafe.Pointer(C.CFDataGetBytePtr(cfDataRef))
 
 	var slice []byte
 	hdrp := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
@@ -48,10 +66,6 @@ func CaptureRect(rect image.Rectangle) (*image.RGBA, error) {
 	for i := 0; i < length; i += 4 {
 		imageBytes[i], imageBytes[i+2], imageBytes[i+1], imageBytes[i+3] = slice[i+2], slice[i], slice[i+1], slice[i+3]
 	}
-
-	C.CFRelease(C.CFTypeRef(cgRawData))
-	C.CFRelease(C.CFTypeRef(cgDataProvider))
-	C.CFRelease(C.CFTypeRef(cgImage))
 
 	img := &image.RGBA{Pix: imageBytes, Stride: 4 * width, Rect: rect}
 	return img, nil


### PR DESCRIPTION
When we last switched to using our fork in production, the agent was crash looping, and appeared to be doing so when we were freeing up resources. This patch:

1. Actually checks for NULL returns from Core Graphics functions that return reference types, and returns errors if they do.
2. Takes advantage of Go's `defer` keyword to ensure any of these references end up getting released regardless of where return occurs.